### PR TITLE
Syntax Errors in GeoSPARQL Queries

### DIFF
--- a/geosparql/illustration/query01.rq
+++ b/geosparql/illustration/query01.rq
@@ -1,4 +1,4 @@
-REFIX my:<http://example.org/ApplicationSchema#>
+PREFIX my:<http://example.org/ApplicationSchema#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
 SELECT ?f

--- a/geosparql/illustration/query05_detail.rq
+++ b/geosparql/illustration/query05_detail.rq
@@ -1,4 +1,4 @@
-REFIX my: <http://example.org/ApplicationSchema#>
+PREFIX my: <http://example.org/ApplicationSchema#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
 SELECT ?f


### PR DESCRIPTION
We found two GeoSPARQL queries with a simple typo which introduces a syntax error and fails to execute (at least) on Virtuoso.