### PR TITLE
Correcting the UNION

### DIFF
--- a/geosparql/illustration/query05_detail.rq
+++ b/geosparql/illustration/query05_detail.rq
@@ -10,28 +10,24 @@ UNION
 ?fGeom geo:asWKT ?fSerial .
 my:A geo:hasDefaultGeometry ?aGeom .
 ?aGeom geo:asWKT ?aSerial .
-FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+FILTER (geof:sfOverlaps(?fSerial, ?aSerial)) }
 UNION
 { # feature – geometry
 ?f geo:hasDefaultGeometry ?fGeom .
 ?fGeom geo:asWKT ?fSerial .
 my:A geo:asWKT ?aSerial .
-FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+FILTER (geof:sfOverlaps(?fSerial, ?aSerial)) }
 UNION
 { # geometry – feature
 ?f geo:asWKT ?fSerial .
 my:A geo:hasDefaultGeometry ?aGeom .
 ?aGeom geo:asWKT ?aSerial .
-FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+FILTER (geof:sfOverlaps(?fSerial, ?aSerial)) }
 UNION
 { # geometry – geometry
 ?f geo:hasDefaultGeometry ?fGeom .
 ?fGeom geo:asWKT ?fSerial .
 my:A geo:hasDefaultGeometry ?aGeom .
 ?aGeom geo:asWKT ?aSerial .
-FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
-}
-}
-}
-}
+FILTER (geof:sfOverlaps(?fSerial, ?aSerial)) }
 }


### PR DESCRIPTION
The UNION should not be nested, but kept on the same level. This is the way it is defined in the source document of these queries, "OGC GeoSPARQL - A Geographic Query Language for RDF Data" (Annex B), available at http://www.opengis.net/doc/IS/geosparql/1.0