### PR TITLE
Fix incorrect 'geof' prefix

### DIFF
--- a/geosparql/illustration/query04.rq
+++ b/geosparql/illustration/query04.rq
@@ -1,14 +1,15 @@
 PREFIX uom: <http://www.opengis.net/def/uom/OGC/1.0/>
 PREFIX my: <http://example.org/ApplicationSchema#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX geof: <http://www.opengis.net/def/geosparql/function>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
 
 SELECT ?f
-WHERE { my:C my:hasExactGeometry ?cGeom .
-?cGeom geo:asWKT ?cWKT .
-?f my:hasExactGeometry ?fGeom .
-?fGeom geo:asWKT ?fWKT .
-FILTER (?fGeom != ?cGeom) }
-ORDER BY ASC (geof:distance(?cWKT, ?fWKT,
-uom:metre))
+WHERE { 
+  my:C my:hasExactGeometry ?cGeom .
+  ?cGeom geo:asWKT ?cWKT .
+  ?f my:hasExactGeometry ?fGeom .
+  ?fGeom geo:asWKT ?fWKT .
+  FILTER (?fGeom != ?cGeom) 
+}
+ORDER BY ASC (geof:distance(?cWKT, ?fWKT, uom:metre))
 LIMIT 3


### PR DESCRIPTION
The correct value of the `geof` prefix is `<http://www.opengis.net/def/function/geosparql/>`, as it is in all other queries.