### PR TITLE
Q04 Answer Fix

### DIFF
--- a/geosparql/illustration/query04.srx
+++ b/geosparql/illustration/query04.srx
@@ -7,10 +7,10 @@
 <binding name='f'><uri>http://example.org/ApplicationSchema#A</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://example.org/ApplicationSchema#D</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#E</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://example.org/ApplicationSchema#E</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#D</uri></binding>
 </result>
 </results>
 </sparql>


### PR DESCRIPTION
Fix for the answer of query 04.

As one of the Virtuoso core developer suggests, this is the reasoning behind the question and the answer:

- A has a distance of zero from C: simply because A touches C.
- E is 0.1d to the West from C: -83.3 for E and -83.2 for C.
- D is 0.1d to the South from C: +34.2 for D and +34.3 for C.

So, the question is what's shorter - 0.1d of longitude at N34.3 latitude (E to C), or 0.1d of latitude at same latitude (D to C).

Well, at N34, 1d of longitude is 92.4km and 1d of latitude is 110.9km.

Therefore, E is closer to C, than D is to C.

---
The question and the answer are part of Annex B of the GeoSPARQL standard: document #11-052r4 from http://www.opengeospatial.org/standards/geosparql, example 4 on page 72 of the PDF / page 54 of the document.